### PR TITLE
Apm 206591 replace get params with header

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -243,8 +243,6 @@ func (h *Hook) download(url, filePath string, buildPackVersion string, language 
 	client := &http.Client{}
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Set("User-Agent", fmt.Sprintf("cf-%s-buildpack/%s", language, buildPackVersion))
-	
-	h.Log.Debug("Setting Authorization Header...")
 	req.Header.Set("Authorization", fmt.Sprintf("Api-Token %s", creds.APIToken))
 
 	out, err := os.Create(filePath)
@@ -311,7 +309,7 @@ func (h *Hook) getDownloadURL(c *credentials) string {
 	}
 
 	qv := make(url.Values)
-	//qv.Add("Api-Token", c.APIToken)
+	qv.Add("Api-Token", c.APIToken)
 	qv.Add("bitness", "64")
 	for _, t := range h.IncludeTechnologies {
 		qv.Add("include", t)

--- a/hook.go
+++ b/hook.go
@@ -87,7 +87,7 @@ func (h *Hook) AfterCompile(stager *libbuildpack.Stager) error {
 	url := h.getDownloadURL(creds)
 
 	h.Log.Info("Downloading '%s' to '%s'", url, installerFilePath)
-	if err = h.download(url, installerFilePath, ver, lang); err != nil {
+	if err = h.download(url, installerFilePath, ver, lang, creds); err != nil {
 		if creds.SkipErrors {
 			h.Log.Warning("Error during installer download, skipping installation")
 			return nil
@@ -237,12 +237,13 @@ func (h *Hook) getCredentials() *credentials {
 }
 
 // download gets url, and stores it as filePath, retrying a few more times if the downloads fail.
-func (h *Hook) download(url, filePath string, buildPackVersion string, language string) error {
+func (h *Hook) download(url, filePath string, buildPackVersion string, language string, creds *credentials) error {
 	const baseWaitTime = 3 * time.Second
 
 	client := &http.Client{}
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Set("User-Agent", fmt.Sprintf("cf-%s-buildpack/%s", language, buildPackVersion))
+	req.Header.Set("Authorization", creds.APIToken)
 
 	out, err := os.Create(filePath)
 	if err != nil {

--- a/hook.go
+++ b/hook.go
@@ -243,6 +243,8 @@ func (h *Hook) download(url, filePath string, buildPackVersion string, language 
 	client := &http.Client{}
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Set("User-Agent", fmt.Sprintf("cf-%s-buildpack/%s", language, buildPackVersion))
+	
+	h.Log.Debug("Setting Authorization Header...")
 	req.Header.Set("Authorization", creds.APIToken)
 
 	out, err := os.Create(filePath)
@@ -309,7 +311,7 @@ func (h *Hook) getDownloadURL(c *credentials) string {
 	}
 
 	qv := make(url.Values)
-	qv.Add("Api-Token", c.APIToken)
+	//qv.Add("Api-Token", c.APIToken)
 	qv.Add("bitness", "64")
 	for _, t := range h.IncludeTechnologies {
 		qv.Add("include", t)

--- a/hook.go
+++ b/hook.go
@@ -245,7 +245,7 @@ func (h *Hook) download(url, filePath string, buildPackVersion string, language 
 	req.Header.Set("User-Agent", fmt.Sprintf("cf-%s-buildpack/%s", language, buildPackVersion))
 	
 	h.Log.Debug("Setting Authorization Header...")
-	req.Header.Set("Authorization", creds.APIToken)
+	req.Header.Set("Authorization", fmt.Sprintf("Api-Token %s", creds.APIToken))
 
 	out, err := os.Create(filePath)
 	if err != nil {

--- a/hook.go
+++ b/hook.go
@@ -309,7 +309,7 @@ func (h *Hook) getDownloadURL(c *credentials) string {
 	}
 
 	qv := make(url.Values)
-	//qv.Add("Api-Token", c.APIToken)
+	qv.Add("Api-Token", c.APIToken)
 	qv.Add("bitness", "64")
 	for _, t := range h.IncludeTechnologies {
 		qv.Add("include", t)

--- a/hook.go
+++ b/hook.go
@@ -309,7 +309,7 @@ func (h *Hook) getDownloadURL(c *credentials) string {
 	}
 
 	qv := make(url.Values)
-	qv.Add("Api-Token", c.APIToken)
+	//qv.Add("Api-Token", c.APIToken)
 	qv.Add("bitness", "64")
 	for _, t := range h.IncludeTechnologies {
 		qv.Add("include", t)

--- a/hook.go
+++ b/hook.go
@@ -243,8 +243,6 @@ func (h *Hook) download(url, filePath string, buildPackVersion string, language 
 	client := &http.Client{}
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Set("User-Agent", fmt.Sprintf("cf-%s-buildpack/%s", language, buildPackVersion))
-
-	h.Log.Debug("Setting Auth Header")
 	req.Header.Set("Authorization", fmt.Sprintf("Api-Token %s", creds.APIToken))
 
 	out, err := os.Create(filePath)

--- a/hook.go
+++ b/hook.go
@@ -309,7 +309,6 @@ func (h *Hook) getDownloadURL(c *credentials) string {
 	}
 
 	qv := make(url.Values)
-	qv.Add("Api-Token", c.APIToken)
 	qv.Add("bitness", "64")
 	for _, t := range h.IncludeTechnologies {
 		qv.Add("include", t)

--- a/hook.go
+++ b/hook.go
@@ -243,6 +243,8 @@ func (h *Hook) download(url, filePath string, buildPackVersion string, language 
 	client := &http.Client{}
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Set("User-Agent", fmt.Sprintf("cf-%s-buildpack/%s", language, buildPackVersion))
+
+	h.Log.Debug("Setting Auth Header")
 	req.Header.Set("Authorization", fmt.Sprintf("Api-Token %s", creds.APIToken))
 
 	out, err := os.Create(filePath)

--- a/hook_test.go
+++ b/hook_test.go
@@ -7,10 +7,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/Dynatrace/libbuildpack-dynatrace"
+	dynatrace "github.com/Dynatrace/libbuildpack-dynatrace"
 	"github.com/cloudfoundry/libbuildpack"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -23,18 +24,19 @@ import (
 
 var _ = Describe("dynatraceHook", func() {
 	var (
-		err          error
-		bpDir        string
-		buildDir     string
-		depsDir      string
-		depsIdx      string
-		logger       *libbuildpack.Logger
-		stager       *libbuildpack.Stager
-		mockCtrl     *gomock.Controller
-		mockCommand  *MockCommand
-		buffer       *bytes.Buffer
-		hook         dynatrace.Hook
-		runInstaller func(string, io.Writer, io.Writer, string, string)
+		err              error
+		bpDir            string
+		buildDir         string
+		depsDir          string
+		depsIdx          string
+		logger           *libbuildpack.Logger
+		stager           *libbuildpack.Stager
+		mockCtrl         *gomock.Controller
+		mockCommand      *MockCommand
+		buffer           *bytes.Buffer
+		hook             dynatrace.Hook
+		runInstaller     func(string, io.Writer, io.Writer, string, string)
+		api_header_check func(req *http.Request) (*http.Response, error)
 	)
 
 	BeforeEach(func() {
@@ -60,6 +62,20 @@ var _ = Describe("dynatraceHook", func() {
 			Log:                 logger,
 			MaxDownloadRetries:  0,
 			IncludeTechnologies: []string{"nginx", "process", "dotnet"},
+		}
+
+		api_header_check = func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, "echo Install Dynatrace")
+
+			resp_header := req.Header.Get("Authorization")
+			if resp_header == "" {
+				return httpmock.NewStringResponse(500, `{"error": "No Authorization Header found"}`), nil
+			}
+			if strings.Index(resp_header, "Api-Token") == -1 {
+				return httpmock.NewStringResponse(500, `{"error": "No Api-Token found in Authorization Header"}`), nil
+			}
+
+			return resp, nil
 		}
 
 		os.Setenv("DT_LOGSTREAM", "")
@@ -242,8 +258,8 @@ var _ = Describe("dynatraceHook", func() {
 					"2": [{"name":"redis"}]
 				}`)
 
-				httpmock.RegisterResponder("GET", "https://example.com/v1/deployment/installer/agent/unix/paas-sh/latest?Api-Token="+apiToken+"&bitness=64&include=nginx&include=process&include=dotnet",
-					httpmock.NewStringResponder(200, "echo Install Dynatrace"))
+				httpmock.RegisterResponder("GET", "https://example.com/v1/deployment/installer/agent/unix/paas-sh/latest?bitness=64&include=nginx&include=process&include=dotnet",
+					api_header_check)
 			})
 
 			It("installs dynatrace", func() {
@@ -273,8 +289,8 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 					"2": [{"name":"redis"}]
 				}`)
 
-				httpmock.RegisterResponder("GET", "https://example.com/v1/deployment/installer/agent/unix/paas-sh/latest?Api-Token="+apiToken+"&bitness=64&include=nginx&include=process&include=dotnet",
-					httpmock.NewStringResponder(200, "echo Install Dynatrace"))
+				httpmock.RegisterResponder("GET", "https://example.com/v1/deployment/installer/agent/unix/paas-sh/latest?bitness=64&include=nginx&include=process&include=dotnet",
+					api_header_check)
 			})
 
 			It("installs dynatrace", func() {
@@ -302,8 +318,8 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 					"2": [{"name":"redis"}]
 				}`)
 
-				httpmock.RegisterResponder("GET", "https://example.com/v1/deployment/installer/agent/unix/paas-sh/latest?Api-Token="+apiToken+"&bitness=64&include=nginx&include=process&include=dotnet",
-					httpmock.NewStringResponder(200, "echo Install Dynatrace"))
+				httpmock.RegisterResponder("GET", "https://example.com/v1/deployment/installer/agent/unix/paas-sh/latest?bitness=64&include=nginx&include=process&include=dotnet",
+					api_header_check)
 			})
 
 			It("installs dynatrace", func() {
@@ -332,8 +348,8 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 					"2": [{"name":"redis"}]
 				}`)
 
-				httpmock.RegisterResponder("GET", "https://example.com/v1/deployment/installer/agent/unix/paas-sh/latest?Api-Token="+apiToken+"&bitness=64&include=nginx&include=process&include=dotnet",
-					httpmock.NewStringResponder(200, "echo Install Dynatrace"))
+				httpmock.RegisterResponder("GET", "https://example.com/v1/deployment/installer/agent/unix/paas-sh/latest?bitness=64&include=nginx&include=process&include=dotnet",
+					api_header_check)
 
 				os.Remove(filepath.Join(bpDir, "VERSION"))
 			})
@@ -364,8 +380,8 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 					"2": [{"name":"redis", "credentials":{"db_type":"redis", "instance_administration_api":{"deployment_id":"12345asdf", "instance_id":"12345asdf", "root":"https://doesnotexi.st"}}}]
 				}`)
 
-				httpmock.RegisterResponder("GET", "https://"+environmentID+".live.dynatrace.com/api/v1/deployment/installer/agent/unix/paas-sh/latest?Api-Token="+apiToken+"&bitness=64&include=nginx&include=process&include=dotnet",
-					httpmock.NewStringResponder(200, "echo Install Dynatrace"))
+				httpmock.RegisterResponder("GET", "https://"+environmentID+".live.dynatrace.com/api/v1/deployment/installer/agent/unix/paas-sh/latest?bitness=64&include=nginx&include=process&include=dotnet",
+					api_header_check)
 			})
 
 			It("installs dynatrace", func() {
@@ -397,7 +413,7 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 				hook.MaxDownloadRetries = 1
 				attempt := 0
 
-				httpmock.RegisterResponder("GET", "https://example.com/v1/deployment/installer/agent/unix/paas-sh/latest?Api-Token="+apiToken+"&bitness=64&include=nginx&include=process&include=dotnet",
+				httpmock.RegisterResponder("GET", "https://example.com/v1/deployment/installer/agent/unix/paas-sh/latest?bitness=64&include=nginx&include=process&include=dotnet",
 					func(req *http.Request) (*http.Response, error) {
 						if attempt += 1; attempt == 1 {
 							return httpmock.NewStringResponse(500, `{"error": "Server failure"}`), nil
@@ -451,8 +467,8 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 					"0": [{"name":"dynatrace","credentials":{"apitoken":"`+apiToken+`","environmentid":"`+environmentID+`","networkzone":"west-us"}}]
 				}`)
 
-				httpmock.RegisterResponder("GET", "https://"+environmentID+".live.dynatrace.com/api/v1/deployment/installer/agent/unix/paas-sh/latest?Api-Token="+apiToken+"&bitness=64&include=nginx&include=process&include=dotnet",
-					httpmock.NewStringResponder(200, "echo Install Dynatrace"))
+				httpmock.RegisterResponder("GET", "https://"+environmentID+".live.dynatrace.com/api/v1/deployment/installer/agent/unix/paas-sh/latest?bitness=64&include=nginx&include=process&include=dotnet",
+					api_header_check)
 			})
 
 			It("installs dynatrace", func() {
@@ -480,7 +496,7 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 					"0": [{"name":"dynatrace","credentials":{"environmentid":"`+environmentID+`","apitoken":"`+apiToken+`","skiperrors":"true"}}]
 				}`)
 
-				httpmock.RegisterResponder("GET", "https://"+environmentID+".live.dynatrace.com/api/v1/deployment/installer/agent/unix/paas-sh/latest?Api-Token="+apiToken+"&bitness=64&include=nginx&include=process&include=dotnet",
+				httpmock.RegisterResponder("GET", "https://"+environmentID+".live.dynatrace.com/api/v1/deployment/installer/agent/unix/paas-sh/latest?bitness=64&include=nginx&include=process&include=dotnet",
 					httpmock.NewStringResponder(404, "echo agent not found"))
 			})
 


### PR DESCRIPTION
- Removed Api-Token from Parameters List
- Added Authorization Header with Api-Token Argument
- Extended the Tests to check for the Authorization Header in the HTTP Request.