### PR TITLE
Added oneagenturl variable to download agent via custom url

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -26,7 +26,7 @@ type Command interface {
 type credentials struct {
 	ServiceName   string
 	EnvironmentID string
-	OneAgentURL   string
+	CustomOneAgentURL   string
 	APIToken      string
 	APIURL        string
 	SkipErrors    bool
@@ -212,7 +212,7 @@ func (h *Hook) getCredentials() *credentials {
 				EnvironmentID: queryString("environmentid"),
 				APIToken:      queryString("apitoken"),
 				APIURL:        queryString("apiurl"),
-				OneAgentURL:   queryString("OneAgentURL"),
+				CustomOneAgentURL:   queryString("CustomOneAgentURL"),
 				SkipErrors:    queryString("skiperrors") == "true",
 				NetworkZone:   queryString("networkzone"),
 			}
@@ -244,7 +244,7 @@ func (h *Hook) download(url, filePath string, buildPackVersion string, language 
 
 	client := &http.Client{}
 	req, _ := http.NewRequest("GET", url, nil)
-	if creds.OneAgentURL == "" {
+	if creds.CustomOneAgentURL == "" {
 		req.Header.Set("User-Agent", fmt.Sprintf("cf-%s-buildpack/%s", language, buildPackVersion))
 		req.Header.Set("Authorization", fmt.Sprintf("Api-Token %s", creds.APIToken))
 	}
@@ -302,8 +302,8 @@ func (h *Hook) download(url, filePath string, buildPackVersion string, language 
 }
 
 func (h *Hook) getDownloadURL(c *credentials) string {
-	if c.OneAgentURL != "" {
-		return c.OneAgentURL
+	if c.CustomOneAgentURL != "" {
+		return c.CustomOneAgentURL
 	}
 
 	apiURL := c.APIURL

--- a/hook.go
+++ b/hook.go
@@ -212,12 +212,12 @@ func (h *Hook) getCredentials() *credentials {
 				EnvironmentID: queryString("environmentid"),
 				APIToken:      queryString("apitoken"),
 				APIURL:        queryString("apiurl"),
-				CustomOneAgentURL:   queryString("CustomOneAgentURL"),
+				CustomOneAgentURL:   queryString("customoneagenturl"),
 				SkipErrors:    queryString("skiperrors") == "true",
 				NetworkZone:   queryString("networkzone"),
 			}
 
-			if creds.EnvironmentID != "" && creds.APIToken != "" {
+			if (creds.EnvironmentID != "" && creds.APIToken != "") || creds.CustomOneAgentURL != "" {
 				found = append(found, creds)
 			} else if !(creds.EnvironmentID == "" && creds.APIToken == "") { // One of the fields is empty.
 				h.Log.Warning("Incomplete credentials for service: %s, environment ID: %s, API token: %s", creds.ServiceName,


### PR DESCRIPTION
This change introduces a new parameter "OneAgentURL" in the VCAP_SERVICES which can be  used to configure custom location to download the agent