### PR TITLE
Add application id env variable

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -170,7 +170,7 @@ func (h *Hook) AfterCompile(stager *libbuildpack.Stager) error {
 	}
 
 	appName := h.getAppName()
-	if appName != nil {
+	if appName != "" {
 		h.Log.Debug("Setting DT_APPLICATIONID...")
 		extra += fmt.Sprintf("\nexport DT_APPLICATIONID=%s", appName)
 	}
@@ -209,7 +209,7 @@ func (h *Hook) AfterCompile(stager *libbuildpack.Stager) error {
 	return nil
 }
 
-// getAppName returns the application name from the environment, or nil if not found. The application JSON object
+// getAppName returns the application name from the environment, or "" if not found. The application JSON object
 // in the VCAP_APPLICATION environment variable is used.
 // see: https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-APPLICATION
 // see: https://docs.dynatrace.com/docs/platform-modules/applications-and-microservices/services/service-detection-and-naming/service-types#expand--web-application-id--3
@@ -222,7 +222,7 @@ func (h *Hook) getAppName() string {
 
 	if err := json.Unmarshal([]byte(os.Getenv("VCAP_APPLICATION")), &application); err != nil {
 		h.Log.Debug("Failed to unmarshal VCAP_APPLICATION: %s", err)
-		return nil
+		return ""
 	}
 	return application.Name
 }

--- a/hook.go
+++ b/hook.go
@@ -216,8 +216,8 @@ func (h *Hook) AfterCompile(stager *libbuildpack.Stager) error {
 func (h *Hook) getAppName() string {
 	// Represent the structure of the JSON object in VCAP_APPLICATION for parsing.
 
-	var application map[string][]struct {
-		Name        string                 `json:"name"`
+	var application struct {
+		Name	string  `json:"name"`
 	}
 
 	if err := json.Unmarshal([]byte(os.Getenv("VCAP_APPLICATION")), &application); err != nil {


### PR DESCRIPTION
Add `DT_APPLICATIONID` env variable

The application id environment variable represents the [web application id](https://docs.dynatrace.com/docs/platform-modules/applications-and-microservices/services/service-detection-and-naming/service-types#expand--web-application-id--3).


This is done in the [Java buildpack](https://github.com/cloudfoundry/java-buildpack/blob/main/lib/java_buildpack/framework/dynatrace_one_agent.rb#L146) as well: the application id is set to the [VCAP_APPLICATION: name](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-APPLICATION).