### PR TITLE
Add multi tech support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# vim session file
+Session.vim

--- a/hook.go
+++ b/hook.go
@@ -101,9 +101,13 @@ func (h *Hook) AfterCompile(stager *libbuildpack.Stager) error {
 	installerFilePath := filepath.Join(os.TempDir(), installerFilename)
 	url := h.getDownloadURL(creds, technologies)
 	err = h.download(url, installerFilePath, stager, creds)
-	if err != nil {
+	if err != nil && creds.SkipErrors {
+		h.Log.Warning("Error during installer download, skipping installation")
+		return nil
+	}else if err != nil {
 		return err
 	}
+
 	// run installer
 	if runtime.GOOS == "linux" {
 		err = h.runInstallerUnix(installerFilePath, installDir, creds, stager)
@@ -268,7 +272,6 @@ func (h *Hook) download(url, filePath string, stager *libbuildpack.Stager, creds
 		time.Sleep(waitTime)
 	}
 
-	//FIXME skiperrors handling missing!
 }
 
 func (h *Hook) getDownloadURL(c *credentials, technologies string) string {

--- a/hook.go
+++ b/hook.go
@@ -412,7 +412,8 @@ func (h *Hook) updateAgentConfig(creds *credentials, installDir string, stager *
 	lang := stager.BuildpackLanguage()
 	ver, err := stager.BuildpackVersion()
 	if err != nil {
-		return err
+		h.Log.Warning("Failed to get buildpack version: %v", err)
+		ver = "unknown"
 	}
 
 	h.Log.Debug("Downloading updated OneAgent config from %s", agentConfigUrl)

--- a/hook.go
+++ b/hook.go
@@ -304,6 +304,7 @@ func (h *Hook) getDownloadURL(c *credentials) string {
 	if c.AddTechnologies != "" {
 		// add optionally configured OneAgent code modules
 		for _, t := range strings.Split(c.AddTechnologies, ",") {
+			h.Log.Debug("Adding additional code module to download: %s", t)
 			qv.Add("include", t)
 		}
 	}

--- a/hook_test.go
+++ b/hook_test.go
@@ -75,13 +75,13 @@ var _ = Describe("dynatraceHook", func() {
 	)
 
 	BeforeEach(func() {
-		bpDir, err = ioutil.TempDir("", "libbuildpack-dynatrace.buildpack.")
+		bpDir, err = os.MkdirTemp("", "libbuildpack-dynatrace.buildpack.")
 		Expect(err).To(BeNil())
 
-		buildDir, err = ioutil.TempDir("", "libbuildpack-dynatrace.build.")
+		buildDir, err = os.MkdirTemp("", "libbuildpack-dynatrace.build.")
 		Expect(err).To(BeNil())
 
-		depsDir, err = ioutil.TempDir("", "libbuildpack-dynatrace.deps.")
+		depsDir, err = os.MkdirTemp("", "libbuildpack-dynatrace.deps.")
 		Expect(err).To(BeNil())
 
 		depsIdx = "07"
@@ -129,13 +129,13 @@ var _ = Describe("dynatraceHook", func() {
 			err = os.MkdirAll(filepath.Join(buildDir, "dynatrace/oneagent/agent/lib64"), 0755)
 			Expect(err).To(BeNil())
 
-			err = ioutil.WriteFile(filepath.Join(buildDir, "dynatrace/oneagent/agent/lib64/liboneagentproc.so"), []byte("library"), 0644)
+			err = os.WriteFile(filepath.Join(buildDir, "dynatrace/oneagent/agent/lib64/liboneagentproc.so"), []byte("library"), 0644)
 			Expect(err).To(BeNil())
 
-			err = ioutil.WriteFile(filepath.Join(buildDir, "dynatrace/oneagent/dynatrace-env.sh"), []byte("echo running dynatrace-env.sh"), 0644)
+			err = os.WriteFile(filepath.Join(buildDir, "dynatrace/oneagent/dynatrace-env.sh"), []byte("echo running dynatrace-env.sh"), 0644)
 			Expect(err).To(BeNil())
 
-			err = ioutil.WriteFile(filepath.Join(buildDir, "dynatrace/oneagent/manifest.json"), []byte(manifestJson), 0664)
+			err = os.WriteFile(filepath.Join(buildDir, "dynatrace/oneagent/manifest.json"), []byte(manifestJson), 0664)
 			Expect(err).To(BeNil())
 
 			ruxitagentproc := `
@@ -150,10 +150,10 @@ var _ = Describe("dynatraceHook", func() {
 			err = os.MkdirAll(filepath.Join(buildDir, "dynatrace/oneagent/agent/conf"), 0755)
 			Expect(err).To(BeNil())
 
-			err = ioutil.WriteFile(filepath.Join(buildDir, "dynatrace/oneagent/agent/conf/ruxitagentproc.conf"), []byte(ruxitagentproc), 0664)
+			err = os.WriteFile(filepath.Join(buildDir, "dynatrace/oneagent/agent/conf/ruxitagentproc.conf"), []byte(ruxitagentproc), 0664)
 			Expect(err).To(BeNil())
 
-			err = ioutil.WriteFile(filepath.Join(buildDir, "dynatrace/oneagent/agent/dt_fips_disabled.flag"), []byte(""), 0664)
+			err = os.WriteFile(filepath.Join(buildDir, "dynatrace/oneagent/agent/dt_fips_disabled.flag"), []byte(""), 0664)
 			Expect(err).To(BeNil())
 		}
 	})

--- a/hook_test.go
+++ b/hook_test.go
@@ -115,8 +115,8 @@ var _ = Describe("dynatraceHook", func() {
 
 		os.Setenv("DT_LOGSTREAM", "")
 
-		ioutil.WriteFile(filepath.Join(bpDir, "manifest.yml"), []byte("---\nlanguage: test42\n"), 0755)
-		ioutil.WriteFile(filepath.Join(bpDir, "VERSION"), []byte("1.2.3"), 0755)
+		os.WriteFile(filepath.Join(bpDir, "manifest.yml"), []byte("---\nlanguage: test42\n"), 0755)
+		os.WriteFile(filepath.Join(bpDir, "VERSION"), []byte("1.2.3"), 0755)
 
 		httpmock.Reset()
 

--- a/hook_test.go
+++ b/hook_test.go
@@ -3,7 +3,6 @@ package dynatrace_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/unix.go
+++ b/unix.go
@@ -82,7 +82,8 @@ func (h *Hook) runInstallerUnix(installerFilePath, installDir string, creds *cre
 
 	ver, err := stager.BuildpackVersion()
 	if err != nil {
-		return err
+		h.Log.Warning("Failed to get buildpack version: %v", err)
+		ver = "unknown"
 	}
 	h.Log.Debug("Preparing custom properties...")
 	extra += fmt.Sprintf(

--- a/windows.go
+++ b/windows.go
@@ -57,7 +57,8 @@ func (h *Hook) setUpDotNetCorProfilerInjection(creds *credentials, installDir st
 
 	ver, err := stager.BuildpackVersion()
 	if err != nil {
-		return nil
+		h.Log.Warning("Failed to get buildpack version: %v", err)
+		ver = "unknown"
 	}
 	h.Log.Debug("Preparing custom properties...")
 	scriptContent += fmt.Sprintf("set DT_CUSTOM_PROP=\"%%DT_CUSTOM_PROP%% CloudFoundryBuildpackLanguage=%s CloudFoundryBuildpackVersion=%s\"\n", stager.BuildpackLanguage(), ver)


### PR DESCRIPTION
This is a bit of a refactor, which was necessary to add easy processing of a new (optional) property that can be configured via a CF service: `addtechnologies`
This configuration property enables a user of a go-based buildpack to add additional OneAgent code-modules as a comma-separated list. Because usually you only get the code-modules for the technology/language of a given buildpack.
This enables monitoring support for multi-buildpack- and sidecar-deployments.