### PR TITLE
DAQ-11432 Correct naming from loader to agent in code and dll references

### DIFF
--- a/hook_test.go
+++ b/hook_test.go
@@ -44,10 +44,10 @@ const manifestJson = `{
 					"version" : "1.130.0.20170914-125024"
 				},  
 				{
-					"path" : "agent/lib64/oneagentloader.dll",
+					"path" : "agent/bin/current/windows-x86-64/oneagentdotnet.dll",
 					"md5" : "2bf4ba9e90e2589428f6f6f3a964cba2",
 					"version" : "1.130.0.20170914-125024",
-					"binarytype" : "loader"
+					"binarytype" : "primary"
 				}
 			]
 		}
@@ -319,7 +319,7 @@ var _ = Describe("dynatraceHook", func() {
 set COR_PROFILER={B7038F67-52FC-4DA2-AB02-969B3C1EDA03}
 set DT_AGENTACTIVE=true
 set DT_BLOCKLIST=powershell*
-set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\lib64\oneagentloader.dll
+set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\bin\current\windows-x86-64\oneagentdotnet.dll
 set DT_CUSTOM_PROP="%DT_CUSTOM_PROP% CloudFoundryBuildpackLanguage=test42 CloudFoundryBuildpackVersion=1.2.3"
 `))
 				} else {
@@ -367,7 +367,7 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 set COR_PROFILER={B7038F67-52FC-4DA2-AB02-969B3C1EDA03}
 set DT_AGENTACTIVE=true
 set DT_BLOCKLIST=powershell*
-set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\lib64\oneagentloader.dll
+set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\bin\current\windows-x86-64\oneagentdotnet.dll
 set DT_CUSTOM_PROP="%DT_CUSTOM_PROP% CloudFoundryBuildpackLanguage=test42 CloudFoundryBuildpackVersion=1.2.3"
 `))
 				} else {
@@ -421,7 +421,7 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 set COR_PROFILER={B7038F67-52FC-4DA2-AB02-969B3C1EDA03}
 set DT_AGENTACTIVE=true
 set DT_BLOCKLIST=powershell*
-set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\lib64\oneagentloader.dll
+set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\bin\current\windows-x86-64\oneagentdotnet.dll
 set DT_CUSTOM_PROP="%DT_CUSTOM_PROP% CloudFoundryBuildpackLanguage=test42 CloudFoundryBuildpackVersion=1.2.3"
 `))
 				} else {
@@ -476,7 +476,7 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 set COR_PROFILER={B7038F67-52FC-4DA2-AB02-969B3C1EDA03}
 set DT_AGENTACTIVE=true
 set DT_BLOCKLIST=powershell*
-set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\lib64\oneagentloader.dll
+set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\bin\current\windows-x86-64\oneagentdotnet.dll
 set DT_CUSTOM_PROP="%DT_CUSTOM_PROP% CloudFoundryBuildpackLanguage=test42 CloudFoundryBuildpackVersion=1.2.3"
 `))
 				} else {
@@ -519,7 +519,7 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 set COR_PROFILER={B7038F67-52FC-4DA2-AB02-969B3C1EDA03}
 set DT_AGENTACTIVE=true
 set DT_BLOCKLIST=powershell*
-set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\lib64\oneagentloader.dll
+set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\bin\current\windows-x86-64\oneagentdotnet.dll
 set DT_CUSTOM_PROP="%DT_CUSTOM_PROP% CloudFoundryBuildpackLanguage=test42 CloudFoundryBuildpackVersion=1.2.3"
 `))
 				} else {
@@ -561,7 +561,7 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 set COR_PROFILER={B7038F67-52FC-4DA2-AB02-969B3C1EDA03}
 set DT_AGENTACTIVE=true
 set DT_BLOCKLIST=powershell*
-set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\lib64\oneagentloader.dll
+set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\bin\current\windows-x86-64\oneagentdotnet.dll
 set DT_CUSTOM_PROP="%DT_CUSTOM_PROP% CloudFoundryBuildpackLanguage=test42 CloudFoundryBuildpackVersion=1.2.3"
 `))
 				} else {
@@ -606,7 +606,7 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 set COR_PROFILER={B7038F67-52FC-4DA2-AB02-969B3C1EDA03}
 set DT_AGENTACTIVE=true
 set DT_BLOCKLIST=powershell*
-set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\lib64\oneagentloader.dll
+set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\bin\current\windows-x86-64\oneagentdotnet.dll
 set DT_CUSTOM_PROP="%DT_CUSTOM_PROP% CloudFoundryBuildpackLanguage=test42 CloudFoundryBuildpackVersion=unknown"
 `))
 				} else {
@@ -649,7 +649,7 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 set COR_PROFILER={B7038F67-52FC-4DA2-AB02-969B3C1EDA03}
 set DT_AGENTACTIVE=true
 set DT_BLOCKLIST=powershell*
-set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\lib64\oneagentloader.dll
+set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\bin\current\windows-x86-64\oneagentdotnet.dll
 set DT_CUSTOM_PROP="%DT_CUSTOM_PROP% CloudFoundryBuildpackLanguage=test42 CloudFoundryBuildpackVersion=1.2.3"
 `))
 				} else {
@@ -704,7 +704,7 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 set COR_PROFILER={B7038F67-52FC-4DA2-AB02-969B3C1EDA03}
 set DT_AGENTACTIVE=true
 set DT_BLOCKLIST=powershell*
-set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\lib64\oneagentloader.dll
+set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\bin\current\windows-x86-64\oneagentdotnet.dll
 set DT_CUSTOM_PROP="%DT_CUSTOM_PROP% CloudFoundryBuildpackLanguage=test42 CloudFoundryBuildpackVersion=1.2.3"
 `))
 				} else {
@@ -760,7 +760,7 @@ export DT_CUSTOM_PROP="${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=test42 Cl
 set COR_PROFILER={B7038F67-52FC-4DA2-AB02-969B3C1EDA03}
 set DT_AGENTACTIVE=true
 set DT_BLOCKLIST=powershell*
-set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\lib64\oneagentloader.dll
+set COR_PROFILER_PATH_64=C:\users\vcap\app\dynatrace\oneagent\agent\bin\current\windows-x86-64\oneagentdotnet.dll
 set DT_NETWORK_ZONE=west-us
 set DT_CUSTOM_PROP="%DT_CUSTOM_PROP% CloudFoundryBuildpackLanguage=test42 CloudFoundryBuildpackVersion=1.2.3"
 `))

--- a/hook_windows_test.go
+++ b/hook_windows_test.go
@@ -19,7 +19,7 @@ const InstallationMethod = "paas"
 func getMockResponse() *http.Response {
 	var zipBytes bytes.Buffer
 	zipWriter := zip.NewWriter(bufio.NewWriter(&zipBytes))
-	writer, _ := zipWriter.Create("agent/lib64/oneagentloader.dll")
+	writer, _ := zipWriter.Create("agent/bin/current/windows-x86-64/oneagentdotnet.dll")
 	writer.Write([]byte("library"))
 	writer, _ = zipWriter.Create("agent/conf/ruxitagentproc.conf")
 	writer.Write([]byte("library"))

--- a/windows.go
+++ b/windows.go
@@ -39,16 +39,16 @@ func (h *Hook) runInstallerWindows(installerFilePath, installDir string, creds *
 }
 
 func (h *Hook) setUpDotNetCorProfilerInjection(creds *credentials, installDir string, stager *libbuildpack.Stager) error {
-	loaderPath, err := h.findAbsoluteLoaderPath(stager, installDir)
+	agentPath, err := h.findAbsoluteAgentPath(stager, installDir)
 	if err != nil {
-		return fmt.Errorf("cannot find oneagentloader.dll: %s", err)
+		return fmt.Errorf("cannot find oneagentdotnet.dll: %s", err)
 	}
 
 	scriptContent := "set COR_ENABLE_PROFILING=1\n"
 	scriptContent += "set COR_PROFILER={B7038F67-52FC-4DA2-AB02-969B3C1EDA03}\n"
 	scriptContent += "set DT_AGENTACTIVE=true\n"
 	scriptContent += "set DT_BLOCKLIST=powershell*\n"
-	scriptContent += fmt.Sprintf("set COR_PROFILER_PATH_64=%s\n", loaderPath)
+	scriptContent += fmt.Sprintf("set COR_PROFILER_PATH_64=%s\n", agentPath)
 
 	if creds.NetworkZone != "" {
 		h.Log.Debug("Setting DT_NETWORK_ZONE...")
@@ -68,32 +68,32 @@ func (h *Hook) setUpDotNetCorProfilerInjection(creds *credentials, installDir st
 	return nil
 }
 
-func (h *Hook) findAbsoluteLoaderPath(stager *libbuildpack.Stager, installDir string) (string, error) {
+func (h *Hook) findAbsoluteAgentPath(stager *libbuildpack.Stager, installDir string) (string, error) {
 
-	// look for dotnet loader DLL file relative to the root of the downloaded zip archive
-	// and get the path from the manifest e.g. agent/bin/windows-x86-64/oneagentloader.dll
-	loaderDllPath, err := h.findAgentPath(filepath.Join(stager.BuildDir(), installDir), "dotnet", "loader", "oneagentloader.dll", "windows-x86-64")
+	// look for dotnet agent DLL file relative to the root of the downloaded zip archive
+	// and get the path from the manifest e.g. agent/bin/windows-x86-64/oneagentdotnet	.dll
+	agentDllPath, err := h.findAgentPath(filepath.Join(stager.BuildDir(), installDir), "dotnet", "primary", "oneagentdotnet.dll", "windows-x86-64")
 	if err != nil {
 		h.Log.Error("Manifest handling failed!")
 		return "", err
 	}
 
 	// windows path separator is "\" instead of "/"
-	loaderDllPath = strings.ReplaceAll(loaderDllPath, "/", "\\")
+	agentDllPath = strings.ReplaceAll(agentDllPath, "/", "\\")
 
-	// build the loader DLL path relative to the app directory
-	// e.g. dynatrace/oneagent/agent/bin/windows-x86-64/oneagentloader.dll
-	loaderDllPathInAppDir := filepath.Join(installDir, loaderDllPath)
+	// build the agent DLL path relative to the app directory
+	// e.g. dynatrace/oneagent/agent/bin/windows-x86-64/oneagentdotnet.dll
+	agentDllPathInAppDir := filepath.Join(installDir, agentDllPath)
 
-	// check that the loader dll is present in the build dir
-	// e.g. at \tmp\app\dynatrace\oneagent\agent\bin\1.303.0.20240930-081133\windows-x86-32\oneagentloader.dll
-	loaderDllPathInBuildDir := filepath.Join(stager.BuildDir(), loaderDllPathInAppDir)
+	// check that the agent dll is present in the build dir
+	// e.g. at \tmp\app\dynatrace\oneagent\agent\bin\1.303.0.20240930-081133\windows-x86-32\oneagentdotnet.dll
+	agentDllPathInBuildDir := filepath.Join(stager.BuildDir(), agentDllPathInAppDir)
 
-	if _, err = os.Stat(loaderDllPathInBuildDir); os.IsNotExist(err) {
-		h.Log.Error("Agent library (%s) not found!", loaderDllPathInBuildDir)
+	if _, err = os.Stat(agentDllPathInBuildDir); os.IsNotExist(err) {
+		h.Log.Error("Agent library (%s) not found!", agentDllPathInBuildDir)
 		return "", err
 	}
 
-	// build the absolute path of the loader DLL as it will be available at runtime
-	return filepath.Join("C:\\users\\vcap\\app", loaderDllPathInAppDir), nil
+	// build the absolute path of the agent DLL as it will be available at runtime
+	return filepath.Join("C:\\users\\vcap\\app", agentDllPathInAppDir), nil
 }


### PR DESCRIPTION
The  oneagentloader.dll was used for loading the dotnet agent. Since there is no symlink on Windows, a OneAgent team renamed the versioned directory to current in the oneagent PassS/standalone package, e.g. 

agent/bin/1.319.9999.90000101-000000/ → agent/bin/current

So they use agent/bin/current/windows-x86-64/oneagentdotnet.dll instead of agent/lib64/oneagentloader.dll when injecting the oneagent without the process on Windows.